### PR TITLE
Correctly handle arrays with nil

### DIFF
--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -86,7 +86,7 @@ class LogStash::Filters::Split < LogStash::Filters::Base
     #or splits[1].empty?
 
     splits.each do |value|
-      next if value.empty?
+      next if value.nil? || value.empty?
 
       event_split = event.clone
       @logger.debug("Split event", :value => value, :field => @field)


### PR DESCRIPTION
if array contains nil values Logstash crashes with `undefined method 'empty?' for nil:NilClass`